### PR TITLE
Fix URL and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.com/wzr1337/teslaStreaming.svg?branch=master)](https://travis-ci.com/wzr1337/teslaStreaming)
 
-This module is used to connect to and listen on the Tesla streaming API, exposed via WebSocket. The API is a convenience method in extension of the regular REST API (<https://teslapi.io>), which needs to be polled.
+This module is used to connect to and listen on the Tesla streaming API, exposed via WebSocket. The API is a convenience method in extension of the regular REST API (<https://teslaapi.io>), which needs to be polled.
 
 This module is **UNOFFICIAL**.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,14 +28,14 @@ export function teslaAPI(vehicleId:string,
 
 
   /*   
-  const subscribMessage = {
+  const subscribeMessage = {
     msg_type: 'data:subscribe',
     token: Buffer.from(`${email}:${vehilce1stToken}`).toString('base64'),
     value: signalNames.join(','),
     tag: vehicleId,
   }; */
 
-  const subscribMessageOAuth = {
+  const subscribeMessageOAuth = {
     msg_type: 'data:subscribe_oauth',
     token: oAuthToken,
     value: signalNames.join(','),
@@ -54,7 +54,7 @@ export function teslaAPI(vehicleId:string,
 
   ws.onopen = () => {
     console.debug(`WebSocket connection established on \`${streamingUrl}\``);
-    ws.send(JSON.stringify(subscribMessageOAuth));
+    ws.send(JSON.stringify(subscribeMessageOAuth));
   }
 
   return sub;


### PR DESCRIPTION
This PR fixes 
* the malformed URL in the README.md by replacing [teslapi.io](teslapi.io) with [teslaapi.io](teslaapi.io).
* The typo in the function name of `subscirbMessageOAuth`
